### PR TITLE
Remove Error Message when the Update Server is down

### DIFF
--- a/src/main/java/me/ikevoodoo/lifestealsmpplugin/LifestealSmpPlugin.java
+++ b/src/main/java/me/ikevoodoo/lifestealsmpplugin/LifestealSmpPlugin.java
@@ -253,7 +253,7 @@ public final class LifestealSmpPlugin extends JavaPlugin {
         try {
             is = getInputStream("http://188.34.178.99:8080/LSSMP/version");
         } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, "Could not check for updates as the server is down/not responding!");
+            //LOGGER.log(Level.SEVERE, "Could not check for updates as the server is down/not responding!");
             return;
         }
         if(is == null) {


### PR DESCRIPTION
Hello,

because your Update Server is down, I removed the Error Message. Please merge the PR so our Consoles are not longer spammed with these Errors.

Thx,
Greenman999